### PR TITLE
Use quote_spanned in Visitor::expand_await

### DIFF
--- a/tests/ui/question-mark-await-type-error.rs
+++ b/tests/ui/question-mark-await-type-error.rs
@@ -1,0 +1,38 @@
+#![feature(async_await, stmt_expr_attributes, proc_macro_hygiene)]
+
+use futures::stream;
+use futures_async_stream::for_await;
+
+async fn async_fn() {
+    for _i in 1..2 {
+        async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    }
+}
+
+#[async_stream(item = i32)]
+async fn async_stream_fn() {
+    for _i in 1..2 {
+        async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    }
+}
+
+// FIXME
+async fn async_fn_and_for_await() {
+    #[for_await]
+    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    for _i in stream::iter(1..2) {
+        async {}.await?;
+    }
+}
+
+// FIXME
+#[async_stream(item = i32)]
+async fn async_stream_fn_and_for_await() {
+    #[for_await]
+    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    for _i in stream::iter(1..2) {
+        async {}.await?;
+    }
+}
+
+fn main() {}

--- a/tests/ui/question-mark-await-type-error.stderr
+++ b/tests/ui/question-mark-await-type-error.stderr
@@ -1,0 +1,244 @@
+error: cannot find attribute macro `async_stream` in this scope
+  --> $DIR/question-mark-await-type-error.rs:12:3
+   |
+12 | #[async_stream(item = i32)]
+   |   ^^^^^^^^^^^^
+
+error: cannot find attribute macro `async_stream` in this scope
+  --> $DIR/question-mark-await-type-error.rs:29:3
+   |
+29 | #[async_stream(item = i32)]
+   |   ^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  |
+  = help: the trait `std::ops::Try` is not implemented for `()`
+  = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+ --> $DIR/question-mark-await-type-error.rs:7:15
+  |
+7 |     for _i in 1..2 {
+  |               ^^^^ cannot infer type for `{integer}`
+  |
+note: the type is part of the `async` object because of this `await`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+ --> $DIR/question-mark-await-type-error.rs:7:15
+  |
+7 |     for _i in 1..2 {
+  |               ^ cannot infer type for `{integer}`
+  |
+note: the type is part of the `async` object because of this `await`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+ --> $DIR/question-mark-await-type-error.rs:7:18
+  |
+7 |     for _i in 1..2 {
+  |                  ^ cannot infer type for `{integer}`
+  |
+note: the type is part of the `async` object because of this `await`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+ --> $DIR/question-mark-await-type-error.rs:7:15
+  |
+7 |     for _i in 1..2 {
+  |               ^^^^ cannot infer type for `{integer}`
+  |
+note: the type is part of the `async` object because of this `await`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+ --> $DIR/question-mark-await-type-error.rs:7:9
+  |
+7 |     for _i in 1..2 {
+  |         ^^ cannot infer type for `{integer}`
+  |
+note: the type is part of the `async` object because of this `await`
+ --> $DIR/question-mark-await-type-error.rs:8:9
+  |
+8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+  |         ^^^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:21:5
+   |
+21 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:14:15
+   |
+14 |     for _i in 1..2 {
+   |               ^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:14:15
+   |
+14 |     for _i in 1..2 {
+   |               ^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:14:18
+   |
+14 |     for _i in 1..2 {
+   |                  ^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:14:15
+   |
+14 |     for _i in 1..2 {
+   |               ^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:14:9
+   |
+14 |     for _i in 1..2 {
+   |         ^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:15:9
+   |
+15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:31:5
+   |
+31 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 22 previous errors
+
+Some errors have detailed explanations: E0277, E0698.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Partially fix bad error messages reported by #6.


* What fixed with this PR is a bad error message when `await?` is used directly in `#[async_stream]`: https://github.com/taiki-e/futures-async-stream/issues/6#issuecomment-517918351
* What cannot be fixed with this PR is a bad error message when `await?` is used in the `for_await`: https://github.com/taiki-e/futures-async-stream/issues/6#issue-476439015.