### PR TITLE
Add support for using async stream functions in traits

### DIFF
--- a/futures-async-stream-macro/src/stream.rs
+++ b/futures-async-stream-macro/src/stream.rs
@@ -5,7 +5,7 @@ use syn::{
     token,
     visit_mut::VisitMut,
     ArgCaptured, Expr, FnArg, FnDecl, Ident, ItemFn, Pat, PatIdent, Result, ReturnType, Token,
-    Type, TypeTuple,
+    Type, TypeTuple, *,
 };
 
 use crate::{
@@ -21,48 +21,171 @@ pub(super) fn async_stream(args: TokenStream, input: TokenStream) -> Result<Toke
     parse_async_stream_fn(args, input)
 }
 
-struct Arg(Type);
-
 mod kw {
     syn::custom_keyword!(item);
+    syn::custom_keyword!(boxed);
+    syn::custom_keyword!(boxed_local);
 }
 
-impl Parse for Arg {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+// item = <Type>
+struct Item(Type);
+
+impl Parse for Item {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let _: kw::item = input.parse()?;
         let _: Token![=] = input.parse()?;
         input.parse().map(Self)
     }
 }
 
-fn parse_async_stream_fn(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
-    let args: Arg = syn::parse2(args)?;
-    let item: ItemFn = syn::parse2(input)?;
+struct Args {
+    item: Type,
+    boxed: ReturnTypeKind,
+}
 
-    if let Some(constness) = item.constness {
+// TODO: rename to `ReturnType`
+#[derive(Clone, Copy)]
+enum ReturnTypeKind {
+    // impl Stream<Item = ..> $(+ $lifetime)?
+    Default,
+    // Pin<Box<dyn Stream<Item = ..> (+ Send)? $(+ $lifetime)?>>
+    Boxed { send: bool },
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut item = None;
+        let mut boxed = ReturnTypeKind::Default;
+        while !input.is_empty() {
+            if input.peek(kw::boxed) {
+                let i: kw::boxed = input.parse()?;
+                match boxed {
+                    ReturnTypeKind::Default => boxed = ReturnTypeKind::Boxed { send: true },
+                    ReturnTypeKind::Boxed { send: true } => {
+                        return Err(error!(i, "duplicate `boxed` argument"))
+                    }
+                    ReturnTypeKind::Boxed { send: false } => {
+                        return Err(error!(
+                            i,
+                            "`boxed` and `boxed_local` cannot be used at the same time."
+                        ))
+                    }
+                }
+            } else if input.peek(kw::boxed_local) {
+                let i: kw::boxed_local = input.parse()?;
+                match boxed {
+                    ReturnTypeKind::Default => boxed = ReturnTypeKind::Boxed { send: false },
+                    ReturnTypeKind::Boxed { send: false } => {
+                        return Err(error!(i, "duplicate `boxed_local` argument"))
+                    }
+                    ReturnTypeKind::Boxed { send: true } => {
+                        return Err(error!(
+                            i,
+                            "`boxed` and `boxed_local` cannot be used at the same time."
+                        ))
+                    }
+                }
+            } else {
+                let i: Item = input.parse()?;
+                if item.is_some() {
+                    return Err(error!(i.0, "duplicate `item` argument"));
+                }
+                item = Some(i.0);
+            }
+            let _: Option<Token![,]> = input.parse()?;
+        }
+
+        if let Some(item) = item {
+            Ok(Self { item, boxed })
+        } else {
+            let _: kw::item = input.parse()?;
+            unreachable!()
+        }
+    }
+}
+
+struct FnSig {
+    attrs: Vec<Attribute>,
+    vis: Visibility,
+    sig: MethodSig,
+    block: Block,
+    semi: Option<Token![;]>,
+}
+
+impl From<ItemFn> for FnSig {
+    fn from(item: ItemFn) -> Self {
+        Self {
+            attrs: item.attrs,
+            vis: item.vis,
+            sig: MethodSig {
+                constness: item.constness,
+                asyncness: item.asyncness,
+                unsafety: item.unsafety,
+                abi: item.abi,
+                ident: item.ident,
+                decl: *item.decl,
+            },
+            block: *item.block,
+            semi: None,
+        }
+    }
+}
+
+impl From<TraitItemMethod> for FnSig {
+    fn from(item: TraitItemMethod) -> Self {
+        if let Some(block) = item.default {
+            Self { attrs: item.attrs, vis: Visibility::Inherited, sig: item.sig, block, semi: None }
+        } else {
+            assert!(item.semi_token.is_some());
+            Self {
+                attrs: item.attrs,
+                vis: Visibility::Inherited,
+                sig: item.sig,
+                block: Block { brace_token: token::Brace::default(), stmts: Vec::new() },
+                semi: item.semi_token,
+            }
+        }
+    }
+}
+
+fn parse_async_stream_fn(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
+    let args: Args = syn::parse2(args)?;
+    let item: FnSig = {
+        let input2 = input.clone();
+        match syn::parse2(input) {
+            Ok(item) => ItemFn::into(item),
+            Err(e) => match syn::parse2(input2) {
+                Ok(item) => TraitItemMethod::into(item),
+                Err(_e) => return Err(e),
+            },
+        }
+    };
+
+    if let Some(constness) = item.sig.constness {
         return Err(error!(constness, "async stream may not be const"));
     }
-    if let Some(variadic) = item.decl.variadic {
+    if let Some(variadic) = item.sig.decl.variadic {
         return Err(error!(variadic, "async stream may not be variadic"));
     }
 
-    if item.asyncness.is_none() {
-        return Err(error!(item.decl.fn_token, "async stream must be declared as async"));
+    if item.sig.asyncness.is_none() {
+        return Err(error!(item.sig.decl.fn_token, "async stream must be declared as async"));
     }
 
-    if let ReturnType::Type(_, ty) = &item.decl.output {
+    if let ReturnType::Type(_, ty) = &item.sig.decl.output {
         match &**ty {
             Type::Tuple(TypeTuple { elems, .. }) if elems.is_empty() => {}
             _ => return Err(error!(ty, "async stream must return the unit type")),
         }
     }
 
-    Ok(expand_async_stream_fn(item, &args.0))
+    Ok(expand_async_stream_fn(item, &args))
 }
 
-fn expand_async_stream_fn(item: ItemFn, item_ty: &Type) -> TokenStream {
-    let ItemFn { ident, vis, unsafety, abi, mut block, decl, attrs, .. } = item;
-    let FnDecl { inputs, mut generics, fn_token, .. } = *decl;
+fn expand_async_stream_fn(item: FnSig, args: &Args) -> TokenStream {
+    let FnSig { attrs, vis, sig, mut block, semi } = item;
+    let MethodSig { unsafety, abi, ident, decl, .. } = sig;
+    let FnDecl { inputs, mut generics, fn_token, .. } = decl;
     let where_clause = &generics.where_clause;
 
     // Desugar `async fn`
@@ -116,7 +239,7 @@ fn expand_async_stream_fn(item: ItemFn, item_ty: &Type) -> TokenStream {
     }
 
     // Visit `#[for_await]` and `.await`.
-    Visitor::new(Stream).visit_block_mut(&mut *block);
+    Visitor::new(Stream).visit_block_mut(&mut block);
 
     let block_inner = quote! {
         #( let #patterns = #temp_bindings; )*
@@ -144,15 +267,22 @@ fn expand_async_stream_fn(item: ItemFn, item_ty: &Type) -> TokenStream {
         gen_body_inner.to_tokens(tokens);
     });
 
-    // Give the invocation of the `from_generator` function the same span as the `item_ty`
+    let item = &args.item;
+
+    // Give the invocation of the `from_generator` function the same span as the `item`
     // as currently errors related to it being a result are targeted here. Not
     // sure if more errors will highlight this function call...
-    let output_span = first_last(item_ty);
+    let output_span = first_last(item);
     let gen_function = quote!(::futures_async_stream::stream::from_generator);
     let gen_function = respan(gen_function, output_span);
-    let body_inner = quote! {
+    let mut body_inner = quote! {
         #gen_function (static move || -> () #gen_body)
     };
+    if let ReturnTypeKind::Boxed { .. } = args.boxed {
+        let body = quote! { ::futures_async_stream::alloc_reexport::boxed::Box::pin(#body_inner) };
+        body_inner = respan(body, output_span);
+    }
+
     let mut body = TokenStream::new();
     block.brace_token.surround(&mut body, |tokens| {
         body_inner.to_tokens(tokens);
@@ -161,12 +291,29 @@ fn expand_async_stream_fn(item: ItemFn, item_ty: &Type) -> TokenStream {
     elision::unelide_lifetimes(&mut generics.params, &mut inputs_no_patterns);
     let lifetimes = generics.lifetimes().map(|l| &l.lifetime);
 
-    // Raw `impl` breaks syntax highlighting in some editors.
-    let impl_token = token::Impl::default();
-    let return_ty = quote! {
-        #impl_token ::futures_async_stream::stream::Stream<Item = #item_ty> + #(#lifetimes +)*
+    let return_ty = match args.boxed {
+        ReturnTypeKind::Default => {
+            // Raw `impl` breaks syntax highlighting in some editors.
+            let impl_token = token::Impl::default();
+            quote! {
+                #impl_token ::futures_async_stream::stream::Stream<Item = #item> + #(#lifetimes +)*
+            }
+        }
+        ReturnTypeKind::Boxed { send } => {
+            let send = if send { Some(quote!(+ Send)) } else { None };
+            quote! {
+                ::futures_async_stream::core_reexport::pin::Pin<
+                    ::futures_async_stream::alloc_reexport::boxed::Box<
+                        dyn ::futures_async_stream::stream::Stream<Item = #item> #send + #(#lifetimes +)*
+                    >
+                >
+            }
+        }
     };
     let return_ty = respan(return_ty, output_span);
+
+    // FIXME
+    let body = semi.map_or_else(|| body, ToTokens::into_token_stream);
     quote! {
         #(#attrs)*
         #vis #unsafety #abi

--- a/tests/ui/bad-item-type.rs
+++ b/tests/ui/bad-item-type.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/bad-item-type.stderr
+++ b/tests/ui/bad-item-type.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/bad-item-type.rs:13:11
+  --> $DIR/bad-item-type.rs:16:11
    |
-13 |     yield val; //~ ERROR mismatched types
+16 |     yield val; //~ ERROR mismatched types
    |           ^^^
    |           |
    |           expected enum `std::option::Option`, found integer
@@ -11,54 +11,54 @@ error[E0308]: mismatched types
               found type `{integer}`
 
 error[E0698]: type inside generator must be known in this context
- --> $DIR/bad-item-type.rs:7:9
-  |
-7 |     let val = Some(42);
-  |         ^^^ cannot infer type for `{integer}`
-  |
-note: the type is part of the generator because of this `yield`
- --> $DIR/bad-item-type.rs:5:1
-  |
-5 | #[async_stream(item = Option<i32>)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:12:9
+  --> $DIR/bad-item-type.rs:10:9
    |
-12 |     let val = val.unwrap();
+10 |     let val = Some(42);
    |         ^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:5:1
+  --> $DIR/bad-item-type.rs:8:1
    |
-5  | #[async_stream(item = Option<i32>)]
+8  | #[async_stream(item = Option<i32>)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:13:11
+  --> $DIR/bad-item-type.rs:15:9
    |
-13 |     yield val; //~ ERROR mismatched types
+15 |     let val = val.unwrap();
+   |         ^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the generator because of this `yield`
+  --> $DIR/bad-item-type.rs:8:1
+   |
+8  | #[async_stream(item = Option<i32>)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0698]: type inside generator must be known in this context
+  --> $DIR/bad-item-type.rs:16:11
+   |
+16 |     yield val; //~ ERROR mismatched types
    |           ^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:5:1
+  --> $DIR/bad-item-type.rs:8:1
    |
-5  | #[async_stream(item = Option<i32>)]
+8  | #[async_stream(item = Option<i32>)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/bad-item-type.rs:21:11
+  --> $DIR/bad-item-type.rs:24:11
    |
-21 |     yield (1, 2) //~ ERROR mismatched types
+24 |     yield (1, 2) //~ ERROR mismatched types
    |           ^^^^^^ expected integer, found tuple
    |
    = note: expected type `{integer}`
               found type `({integer}, {integer})`
 
 error[E0271]: type mismatch resolving `<impl futures_core::stream::Stream as futures_core::stream::Stream>::Item == (i32, i32)`
-  --> $DIR/bad-item-type.rs:16:23
+  --> $DIR/bad-item-type.rs:19:23
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    |                       ^^^^^^^^^^ expected integer, found tuple
    |
    = note: expected type `{integer}`
@@ -66,63 +66,63 @@ error[E0271]: type mismatch resolving `<impl futures_core::stream::Stream as fut
    = note: the return type of a function must have a statically known size
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:19:15
+  --> $DIR/bad-item-type.rs:22:15
    |
-19 |         yield 3;
+22 |         yield 3;
    |               ^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:21:12
+  --> $DIR/bad-item-type.rs:24:12
    |
-21 |     yield (1, 2) //~ ERROR mismatched types
+24 |     yield (1, 2) //~ ERROR mismatched types
    |            ^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:21:15
+  --> $DIR/bad-item-type.rs:24:15
    |
-21 |     yield (1, 2) //~ ERROR mismatched types
+24 |     yield (1, 2) //~ ERROR mismatched types
    |               ^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0698]: type inside generator must be known in this context
-  --> $DIR/bad-item-type.rs:21:11
+  --> $DIR/bad-item-type.rs:24:11
    |
-21 |     yield (1, 2) //~ ERROR mismatched types
+24 |     yield (1, 2) //~ ERROR mismatched types
    |           ^^^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the generator because of this `yield`
-  --> $DIR/bad-item-type.rs:16:1
+  --> $DIR/bad-item-type.rs:19:1
    |
-16 | #[async_stream(item = (i32, i32))]
+19 | #[async_stream(item = (i32, i32))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 11 previous errors

--- a/tests/ui/forget-semicolon.rs
+++ b/tests/ui/forget-semicolon.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/forget-semicolon.stderr
+++ b/tests/ui/forget-semicolon.stderr
@@ -1,13 +1,13 @@
 error[E0308]: mismatched types
- --> $DIR/forget-semicolon.rs:8:5
-  |
-8 |     Some(()) //~ ERROR mismatched types
-  |     ^^^^^^^^- help: try adding a semicolon: `;`
-  |     |
-  |     expected (), found enum `std::option::Option`
-  |
-  = note: expected type `()`
-             found type `std::option::Option<()>`
+  --> $DIR/forget-semicolon.rs:11:5
+   |
+11 |     Some(()) //~ ERROR mismatched types
+   |     ^^^^^^^^- help: try adding a semicolon: `;`
+   |     |
+   |     expected (), found enum `std::option::Option`
+   |
+   = note: expected type `()`
+              found type `std::option::Option<()>`
 
 error: aborting due to previous error
 

--- a/tests/ui/invalid-arguments.rs
+++ b/tests/ui/invalid-arguments.rs
@@ -1,10 +1,13 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures::stream;
 use futures_async_stream::async_stream;
 
 #[async_stream(item = i32)]
-async fn foo() {
+async fn a() {
     #[for_await(bar)] //~ ERROR unexpected token
     for i in stream::iter(vec![1, 2]) {
         yield i;
@@ -12,19 +15,33 @@ async fn foo() {
 }
 
 #[async_stream(baz, item = i32)] //~ ERROR expected `item`
-async fn bar() {
-    #[for_await]
-    for i in stream::iter(vec![1, 2]) {
-        yield i;
-    }
+async fn b() {
+    yield 1;
 }
 
 #[async_stream(item = i32, baz)] //~ ERROR unexpected token
-async fn baz() {
-    #[for_await]
-    for i in stream::iter(vec![1, 2]) {
-        yield i;
-    }
+async fn c() {
+    yield 1;
+}
+
+#[async_stream(item = i32, item = i32)] //~ ERROR duplicate `item` argument
+async fn duplicate_item() {
+    yield 1;
+}
+
+#[async_stream(item = i32, boxed, boxed)] //~ ERROR duplicate `boxed` argument
+async fn duplicate_boxed() {
+    yield 1;
+}
+
+#[async_stream(item = i32, boxed_local, boxed_local)] //~ ERROR duplicate `boxed_local` argument
+async fn duplicate_boxed_local() {
+    yield 1;
+}
+
+#[async_stream(item = i32, boxed_local, boxed)] //~ ERROR `boxed` and `boxed_local` cannot be used at the same time.
+async fn c() {
+    yield 1;
 }
 
 fn main() {}

--- a/tests/ui/invalid-arguments.stderr
+++ b/tests/ui/invalid-arguments.stderr
@@ -1,20 +1,44 @@
 error: unexpected token
- --> $DIR/invalid-arguments.rs:8:16
-  |
-8 |     #[for_await(bar)] //~ ERROR unexpected token
-  |                ^^^^^
+  --> $DIR/invalid-arguments.rs:11:16
+   |
+11 |     #[for_await(bar)] //~ ERROR unexpected token
+   |                ^^^^^
 
 error: expected `item`
-  --> $DIR/invalid-arguments.rs:14:16
+  --> $DIR/invalid-arguments.rs:17:16
    |
-14 | #[async_stream(baz, item = i32)] //~ ERROR expected `item`
+17 | #[async_stream(baz, item = i32)] //~ ERROR expected `item`
    |                ^^^
 
-error: unexpected token
-  --> $DIR/invalid-arguments.rs:22:26
+error: expected `item`
+  --> $DIR/invalid-arguments.rs:22:28
    |
 22 | #[async_stream(item = i32, baz)] //~ ERROR unexpected token
-   |                          ^
+   |                            ^^^
 
-error: aborting due to 3 previous errors
+error: duplicate `item` argument
+  --> $DIR/invalid-arguments.rs:27:35
+   |
+27 | #[async_stream(item = i32, item = i32)] //~ ERROR duplicate `item` argument
+   |                                   ^^^
+
+error: duplicate `boxed` argument
+  --> $DIR/invalid-arguments.rs:32:35
+   |
+32 | #[async_stream(item = i32, boxed, boxed)] //~ ERROR duplicate `boxed` argument
+   |                                   ^^^^^
+
+error: duplicate `boxed_local` argument
+  --> $DIR/invalid-arguments.rs:37:41
+   |
+37 | #[async_stream(item = i32, boxed_local, boxed_local)] //~ ERROR duplicate `boxed_local` argument
+   |                                         ^^^^^^^^^^^
+
+error: `boxed` and `boxed_local` cannot be used at the same time.
+  --> $DIR/invalid-arguments.rs:42:41
+   |
+42 | #[async_stream(item = i32, boxed_local, boxed)] //~ ERROR `boxed` and `boxed_local` cannot be used at the same time.
+   |                                         ^^^^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/invalid-function.rs
+++ b/tests/ui/invalid-function.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/invalid-function.stderr
+++ b/tests/ui/invalid-function.stderr
@@ -1,27 +1,27 @@
 error: only foreign functions are allowed to be C-variadic
- --> $DIR/invalid-function.rs:9:13
-  |
-9 | fn variadic(...) {} //~ ERROR async stream may not be variadic
-  |             ^^^
+  --> $DIR/invalid-function.rs:12:13
+   |
+12 | fn variadic(...) {} //~ ERROR async stream may not be variadic
+   |             ^^^
 
 error: async stream may not be const
- --> $DIR/invalid-function.rs:6:1
+ --> $DIR/invalid-function.rs:9:1
   |
-6 | const fn constness() {} //~ ERROR async stream may not be const
+9 | const fn constness() {} //~ ERROR async stream may not be const
   | ^^^^^
 
 error: async stream must be declared as async
 
 error: async stream must be declared as async
-  --> $DIR/invalid-function.rs:12:1
+  --> $DIR/invalid-function.rs:15:1
    |
-12 | fn asyncness() {} //~ ERROR async stream must be declared as async
+15 | fn asyncness() {} //~ ERROR async stream must be declared as async
    | ^^
 
 error: async stream must return the unit type
-  --> $DIR/invalid-function.rs:15:22
+  --> $DIR/invalid-function.rs:18:22
    |
-15 | async fn output() -> i32 {} //~ ERROR async stream must return the unit type
+18 | async fn output() -> i32 {} //~ ERROR async stream must return the unit type
    |                      ^^^
 
 error: aborting due to 5 previous errors

--- a/tests/ui/missing-item.rs
+++ b/tests/ui/missing-item.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/missing-item.stderr
+++ b/tests/ui/missing-item.stderr
@@ -1,7 +1,7 @@
 error: unexpected end of input, expected `item`
- --> $DIR/missing-item.rs:5:1
+ --> $DIR/missing-item.rs:8:1
   |
-5 | #[async_stream] //~ ERROR unexpected end of input, expected `item`
+8 | #[async_stream] //~ ERROR unexpected end of input, expected `item`
   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/ui/move-captured-variable.rs
+++ b/tests/ui/move-captured-variable.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators, proc_macro_hygiene)]
 
 use futures_async_stream::async_stream_block;

--- a/tests/ui/move-captured-variable.stderr
+++ b/tests/ui/move-captured-variable.stderr
@@ -1,16 +1,16 @@
 error[E0507]: cannot move out of `a`, a captured variable in an `FnMut` closure
-  --> $DIR/move-captured-variable.rs:10:9
+  --> $DIR/move-captured-variable.rs:13:9
    |
-8  |       let a = String::new();
+11 |       let a = String::new();
    |           - captured outer variable
-9  |       foo(|| {
-10 | /         async_stream_block! { //~ ERROR cannot move out of `a`, a captured variable in an `FnMut` closure
-11 | |             yield a
+12 |       foo(|| {
+13 | /         async_stream_block! { //~ ERROR cannot move out of `a`, a captured variable in an `FnMut` closure
+14 | |             yield a
    | |                   -
    | |                   |
    | |                   move occurs because `a` has type `std::string::String`, which does not implement the `Copy` trait
    | |                   move occurs due to use in generator
-12 | |         };
+15 | |         };
    | |__________^ move out of `a` occurs here
 
 error: aborting due to previous error

--- a/tests/ui/nested.rs
+++ b/tests/ui/nested.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures::stream;

--- a/tests/ui/nested.stderr
+++ b/tests/ui/nested.stderr
@@ -1,7 +1,7 @@
 error[E0727]: `async` generators are not yet supported
-  --> $DIR/nested.rs:11:13
+  --> $DIR/nested.rs:14:13
    |
-11 |             yield i * i; //~ ERROR `async` generators are not yet supported [E0727]
+14 |             yield i * i; //~ ERROR `async` generators are not yet supported [E0727]
    |             ^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/ui/question-mark-await-type-error.rs
+++ b/tests/ui/question-mark-await-type-error.rs
@@ -1,4 +1,7 @@
-#![feature(async_await, stmt_expr_attributes, proc_macro_hygiene)]
+// compile-fail
+
+#![deny(warnings)]
+#![feature(async_await, generators, stmt_expr_attributes, proc_macro_hygiene)]
 
 use futures::stream;
 use futures_async_stream::for_await;

--- a/tests/ui/question-mark-await-type-error.stderr
+++ b/tests/ui/question-mark-await-type-error.stderr
@@ -1,241 +1,241 @@
 error: cannot find attribute macro `async_stream` in this scope
-  --> $DIR/question-mark-await-type-error.rs:12:3
+  --> $DIR/question-mark-await-type-error.rs:15:3
    |
-12 | #[async_stream(item = i32)]
+15 | #[async_stream(item = i32)]
    |   ^^^^^^^^^^^^
 
 error: cannot find attribute macro `async_stream` in this scope
-  --> $DIR/question-mark-await-type-error.rs:29:3
+  --> $DIR/question-mark-await-type-error.rs:32:3
    |
-29 | #[async_stream(item = i32)]
+32 | #[async_stream(item = i32)]
    |   ^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
-  |
-  = help: the trait `std::ops::Try` is not implemented for `()`
-  = note: required by `std::ops::Try::into_result`
-
-error[E0698]: type inside `async` object must be known in this context
- --> $DIR/question-mark-await-type-error.rs:7:15
-  |
-7 |     for _i in 1..2 {
-  |               ^^^^ cannot infer type for `{integer}`
-  |
-note: the type is part of the `async` object because of this `await`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
- --> $DIR/question-mark-await-type-error.rs:7:15
-  |
-7 |     for _i in 1..2 {
-  |               ^ cannot infer type for `{integer}`
-  |
-note: the type is part of the `async` object because of this `await`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
- --> $DIR/question-mark-await-type-error.rs:7:18
-  |
-7 |     for _i in 1..2 {
-  |                  ^ cannot infer type for `{integer}`
-  |
-note: the type is part of the `async` object because of this `await`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
- --> $DIR/question-mark-await-type-error.rs:7:15
-  |
-7 |     for _i in 1..2 {
-  |               ^^^^ cannot infer type for `{integer}`
-  |
-note: the type is part of the `async` object because of this `await`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
- --> $DIR/question-mark-await-type-error.rs:7:9
-  |
-7 |     for _i in 1..2 {
-  |         ^^ cannot infer type for `{integer}`
-  |
-note: the type is part of the `async` object because of this `await`
- --> $DIR/question-mark-await-type-error.rs:8:9
-  |
-8 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-  |         ^^^^^^^^^^^^^^
-
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/question-mark-await-type-error.rs:21:5
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
-   |
-   = help: the trait `std::ops::Try` is not implemented for `()`
-   = note: required by `std::ops::Try::into_result`
-
-error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
-   |
-note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
-   |
-note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^
-
-error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
-   |
-note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:21:5
-   |
-21 |     #[for_await]
-   |     ^^^^^^^^^^^^
-
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/question-mark-await-type-error.rs:15:9
-   |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
    |
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::into_result`
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:14:15
+  --> $DIR/question-mark-await-type-error.rs:10:15
    |
-14 |     for _i in 1..2 {
+10 |     for _i in 1..2 {
    |               ^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:15:9
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:14:15
+  --> $DIR/question-mark-await-type-error.rs:10:15
    |
-14 |     for _i in 1..2 {
+10 |     for _i in 1..2 {
    |               ^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:15:9
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:14:18
+  --> $DIR/question-mark-await-type-error.rs:10:18
    |
-14 |     for _i in 1..2 {
+10 |     for _i in 1..2 {
    |                  ^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:15:9
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:14:15
+  --> $DIR/question-mark-await-type-error.rs:10:15
    |
-14 |     for _i in 1..2 {
+10 |     for _i in 1..2 {
    |               ^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:15:9
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:14:9
+  --> $DIR/question-mark-await-type-error.rs:10:9
    |
-14 |     for _i in 1..2 {
+10 |     for _i in 1..2 {
    |         ^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:15:9
+  --> $DIR/question-mark-await-type-error.rs:11:9
    |
-15 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+11 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
    |         ^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
    |
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::into_result`
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^
 
 error[E0698]: type inside `async` object must be known in this context
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
    |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
    |
 note: the type is part of the `async` object because of this `await`
-  --> $DIR/question-mark-await-type-error.rs:31:5
+  --> $DIR/question-mark-await-type-error.rs:24:5
    |
-31 |     #[for_await]
+24 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:17:15
+   |
+17 |     for _i in 1..2 {
+   |               ^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:17:15
+   |
+17 |     for _i in 1..2 {
+   |               ^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:17:18
+   |
+17 |     for _i in 1..2 {
+   |                  ^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:17:15
+   |
+17 |     for _i in 1..2 {
+   |               ^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:17:9
+   |
+17 |     for _i in 1..2 {
+   |         ^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:18:9
+   |
+18 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   |         ^^^^^^^^^^^^^^
+
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::into_result`
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^
+
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
+   |     ^^^^^^^^^^^^ cannot infer type for `{integer}`
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/question-mark-await-type-error.rs:34:5
+   |
+34 |     #[for_await]
    |     ^^^^^^^^^^^^
 
 error: aborting due to 22 previous errors

--- a/tests/ui/threads-sendsync.rs
+++ b/tests/ui/threads-sendsync.rs
@@ -1,0 +1,31 @@
+// compile-fail
+
+#![deny(warnings)]
+#![feature(async_await, generators)]
+
+use futures_async_stream::async_stream;
+
+fn assert_send<T: Send>(_: T) {}
+fn assert_sync<T: Send>(_: T) {}
+
+#[async_stream(item = i32)]
+pub async fn unboxed() {
+    yield 0;
+}
+
+#[async_stream(boxed, item = i32)]
+pub async fn boxed() {
+    yield 0;
+}
+
+#[async_stream(boxed_local, item = i32)]
+pub async fn boxed_local() {
+    yield 0;
+}
+
+fn main() {
+    assert_send(unboxed());
+    assert_sync(unboxed());
+    assert_send(boxed());
+    assert_send(boxed_local()); //~ ERROR `dyn futures_core::stream::Stream<Item = i32>` cannot be sent between threads safely
+}

--- a/tests/ui/threads-sendsync.stderr
+++ b/tests/ui/threads-sendsync.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `dyn futures_core::stream::Stream<Item = i32>` cannot be sent between threads safely
+  --> $DIR/threads-sendsync.rs:30:5
+   |
+30 |     assert_send(boxed_local()); //~ ERROR `dyn futures_core::stream::Stream<Item = i32>` cannot be sent between threads safely
+   |     ^^^^^^^^^^^ `dyn futures_core::stream::Stream<Item = i32>` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `dyn futures_core::stream::Stream<Item = i32>`
+   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dyn futures_core::stream::Stream<Item = i32>>`
+   = note: required because it appears within the type `std::boxed::Box<dyn futures_core::stream::Stream<Item = i32>>`
+   = note: required because it appears within the type `std::pin::Pin<std::boxed::Box<dyn futures_core::stream::Stream<Item = i32>>>`
+note: required by `assert_send`
+  --> $DIR/threads-sendsync.rs:8:1
+   |
+8  | fn assert_send<T: Send>(_: T) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-error.rs
+++ b/tests/ui/type-error.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/type-error.stderr
+++ b/tests/ui/type-error.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
- --> $DIR/type-error.rs:7:18
-  |
-7 |     let a: i32 = "a"; //~ ERROR mismatched types
-  |                  ^^^ expected i32, found reference
-  |
-  = note: expected type `i32`
-             found type `&'static str`
+  --> $DIR/type-error.rs:10:18
+   |
+10 |     let a: i32 = "a"; //~ ERROR mismatched types
+   |                  ^^^ expected i32, found reference
+   |
+   = note: expected type `i32`
+              found type `&'static str`
 
 error: aborting due to previous error
 

--- a/tests/ui/unresolved-type.rs
+++ b/tests/ui/unresolved-type.rs
@@ -1,3 +1,6 @@
+// compile-fail
+
+#![deny(warnings)]
 #![feature(async_await, generators)]
 
 use futures_async_stream::async_stream;

--- a/tests/ui/unresolved-type.stderr
+++ b/tests/ui/unresolved-type.stderr
@@ -1,17 +1,17 @@
 error[E0412]: cannot find type `Left` in this scope
- --> $DIR/unresolved-type.rs:5:23
+ --> $DIR/unresolved-type.rs:8:23
   |
-5 | #[async_stream(item = Left)] //~ ERROR cannot find type `Left` in this scope
+8 | #[async_stream(item = Left)] //~ ERROR cannot find type `Left` in this scope
   |                       ^^^^ not found in this scope
 help: there is an enum variant `core::fmt::Alignment::Left` and 9 others; try using the variant's enum
   |
-5 | #[async_stream(item = core::fmt::Alignment)] //~ ERROR cannot find type `Left` in this scope
+8 | #[async_stream(item = core::fmt::Alignment)] //~ ERROR cannot find type `Left` in this scope
   |                       ^^^^^^^^^^^^^^^^^^^^
-5 | #[async_stream(item = core::fmt::rt::v1::Alignment)] //~ ERROR cannot find type `Left` in this scope
+8 | #[async_stream(item = core::fmt::rt::v1::Alignment)] //~ ERROR cannot find type `Left` in this scope
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5 | #[async_stream(item = futures::core_reexport::fmt::Alignment)] //~ ERROR cannot find type `Left` in this scope
+8 | #[async_stream(item = futures::core_reexport::fmt::Alignment)] //~ ERROR cannot find type `Left` in this scope
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-5 | #[async_stream(item = futures::core_reexport::fmt::rt::v1::Alignment)] //~ ERROR cannot find type `Left` in this scope
+8 | #[async_stream(item = futures::core_reexport::fmt::rt::v1::Alignment)] //~ ERROR cannot find type `Left` in this scope
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 and 5 other candidates
 


### PR DESCRIPTION
You can use async stream functions in traits by passing `boxed` or `boxed_local` as an argument.

```rust
#![feature(async_await, generators)]
use futures_async_stream::async_stream;

trait Foo {
    #[async_stream(boxed, item = u32)]
    async fn method(&mut self);
}

struct Bar(u32);

impl Foo for Bar {
    #[async_stream(boxed, item = u32)]
    async fn method(&mut self) {
        while self.0 < u32::max_value() {
            self.0 += 1;
            yield self.0;
        }
    }
}
```

A async stream function that received a `boxed` argument is converted to a function that returns `Pin<Box<dyn Stream<Item = item> + Send + 'lifetime>>`.
If you passed `boxed_local` instead of `boxed`, async stream function returns a non-threadsafe stream (`Pin<Box<dyn Stream<Item = item> + 'lifetime>>`).

```rust
#![feature(async_await, generators)]
use futures::stream::Stream;
use futures_async_stream::async_stream;
use std::pin::Pin;

// The trait itself can be defined without unstable features.
trait Foo {
    fn method(&mut self) -> Pin<Box<dyn Stream<Item = u32> + Send + '_>>;
}

struct Bar(u32);

impl Foo for Bar {
    #[async_stream(boxed, item = u32)]
    async fn method(&mut self) {
        while self.0 < u32::max_value() {
            self.0 += 1;
            yield self.0;
        }
    }
}
```

Closes #10