### PR TITLE
Add async_try_stream to support ? operator in async stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ description = """
 Async stream for Rust and the futures crate.
 """
 
+[package.metadata.docs.rs]
+all-features = true
+
 [workspace]
 members = ["futures-async-stream-macro"]
 

--- a/futures-async-stream-macro/Cargo.toml
+++ b/futures-async-stream-macro/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Definition of the `#[async_stream]` macro for the `futures-async-stream` crate as well as a few other assorted macros.
 """
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 proc-macro = true
 

--- a/futures-async-stream-macro/src/lib.rs
+++ b/futures-async-stream-macro/src/lib.rs
@@ -22,6 +22,7 @@ mod utils;
 
 mod elision;
 mod stream;
+mod try_stream;
 mod visitor;
 
 /// Processes streams using a for loop.
@@ -40,12 +41,25 @@ pub fn for_await(args: TokenStream, input: TokenStream) -> TokenStream {
 /// Creates streams via generators.
 #[proc_macro_attribute]
 pub fn async_stream(args: TokenStream, input: TokenStream) -> TokenStream {
-    stream::async_stream(args.into(), input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
+    stream::attribute(args.into(), input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
 }
 
 /// Creates streams via generators.
 #[proc_macro]
 pub fn async_stream_block(input: TokenStream) -> TokenStream {
     let input = TokenStream::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
-    stream::async_stream_block(input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
+    stream::block_macro(input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
+}
+
+/// Creates streams via generators.
+#[proc_macro_attribute]
+pub fn async_try_stream(args: TokenStream, input: TokenStream) -> TokenStream {
+    try_stream::attribute(args.into(), input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
+}
+
+/// Creates streams via generators.
+#[proc_macro]
+pub fn async_try_stream_block(input: TokenStream) -> TokenStream {
+    let input = TokenStream::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
+    try_stream::block_macro(input.into()).unwrap_or_else(|e| e.to_compile_error()).into()
 }

--- a/futures-async-stream-macro/src/try_stream.rs
+++ b/futures-async-stream-macro/src/try_stream.rs
@@ -1,0 +1,183 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    visit_mut::VisitMut,
+    *,
+};
+
+use crate::{
+    elision,
+    stream::{expand_async_body, make_gen_body, validate_async_stream_fn, FnSig, ReturnTypeKind},
+    utils::{block, first_last, respan},
+    visitor::{TryStream, Visitor},
+};
+
+// =================================================================================================
+// async_try_stream
+
+pub(super) fn attribute(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
+    parse_async_try_stream_fn(args, input)
+}
+
+mod kw {
+    syn::custom_keyword!(ok);
+    syn::custom_keyword!(error);
+}
+
+// ok = <Type>
+struct Ok_(Type);
+
+impl Parse for Ok_ {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let _: kw::ok = input.parse()?;
+        let _: Token![=] = input.parse()?;
+        input.parse().map(Self)
+    }
+}
+
+// error = <Type>
+struct Error_(Type);
+
+impl Parse for Error_ {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let _: kw::error = input.parse()?;
+        let _: Token![=] = input.parse()?;
+        input.parse().map(Self)
+    }
+}
+
+struct Args {
+    ok: Type,
+    error: Type,
+    boxed: ReturnTypeKind,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut ok = None;
+        let mut error = None;
+        let mut boxed = ReturnTypeKind::Default;
+        boxed.parse_or_else(input, |input| {
+            if input.peek(kw::ok) {
+                let i: Ok_ = input.parse()?;
+                if ok.is_some() {
+                    Err(error!(i.0, "duplicate `ok` argument"))
+                } else {
+                    ok = Some(i.0);
+                    Ok(())
+                }
+            } else {
+                let i: Error_ = input.parse()?;
+                if error.is_some() {
+                    Err(error!(i.0, "duplicate `error` argument"))
+                } else {
+                    error = Some(i.0);
+                    Ok(())
+                }
+            }
+        })?;
+
+        match (ok, error) {
+            (Some(ok), Some(error)) => Ok(Self { ok, error, boxed }),
+            (Some(_), None) => input.parse::<kw::error>().map(|_| unreachable!()),
+            (None, _) => input.parse::<kw::ok>().map(|_| unreachable!()),
+        }
+    }
+}
+
+fn parse_async_try_stream_fn(args: TokenStream, input: TokenStream) -> Result<TokenStream> {
+    let args: Args = syn::parse2(args)?;
+    let item = FnSig::parse(input, args.boxed)?;
+
+    validate_async_stream_fn(&item)?;
+    Ok(expand_async_try_stream_fn(item, &args))
+}
+
+fn expand_async_try_stream_fn(item: FnSig, args: &Args) -> TokenStream {
+    let FnSig { attrs, vis, sig, mut block, semi } = item;
+    let Signature { unsafety, abi, fn_token, ident, mut generics, inputs, .. } = sig;
+    let where_clause = &generics.where_clause;
+
+    let (mut arguments, statements) = expand_async_body(inputs);
+
+    // Visit `#[for_await]` and `.await`.
+    Visitor::new(TryStream).visit_block_mut(&mut block);
+
+    let ok = &args.ok;
+    let error = &args.error;
+
+    // Give the invocation of the `from_generator` function the same span as the `item_ty`
+    // as currently errors related to it being a result are targeted here. Not
+    // sure if more errors will highlight this function call...
+    let output_span = first_last(ok);
+    let gen_function = quote!(::futures_async_stream::try_stream::from_generator);
+    let gen_function = respan(gen_function, output_span);
+    let ret_ty = quote!(::futures_async_stream::reexport::result::Result<(), #error>);
+    let mut body_inner =
+        make_gen_body(&statements, &block, &gen_function, &quote!(Ok(())), &ret_ty);
+
+    if let ReturnTypeKind::Boxed { .. } = args.boxed {
+        let body = quote! { ::futures_async_stream::reexport::boxed::Box::pin(#body_inner) };
+        body_inner = respan(body, output_span);
+    }
+
+    let mut body = TokenStream::new();
+    block.brace_token.surround(&mut body, |tokens| {
+        body_inner.to_tokens(tokens);
+    });
+
+    elision::unelide_lifetimes(&mut generics.params, &mut arguments);
+    let lifetimes = generics.lifetimes().map(|l| &l.lifetime);
+
+    let return_ty = match args.boxed {
+        ReturnTypeKind::Default => {
+            // Raw `impl` breaks syntax highlighting in some editors.
+            let impl_token = token::Impl::default();
+            quote! {
+                #impl_token ::futures_async_stream::reexport::Stream<
+                    Item = ::futures_async_stream::reexport::result::Result<#ok, #error>
+                > + #(#lifetimes +)*
+            }
+        }
+        ReturnTypeKind::Boxed { send } => {
+            let send = if send { Some(quote!(+ Send)) } else { None };
+            quote! {
+                ::futures_async_stream::reexport::pin::Pin<
+                    ::futures_async_stream::reexport::boxed::Box<
+                        dyn ::futures_async_stream::reexport::Stream<
+                            Item = ::futures_async_stream::reexport::result::Result<#ok, #error>
+                        > #send + #(#lifetimes +)*
+                    >
+                >
+            }
+        }
+    };
+    let return_ty = respan(return_ty, output_span);
+
+    // FIXME
+    let body = semi.map_or_else(|| body, ToTokens::into_token_stream);
+    quote! {
+        #(#attrs)*
+        #vis #unsafety #abi
+        #fn_token #ident #generics (#(#arguments),*)
+            -> #return_ty
+            #where_clause
+        #body
+    }
+}
+
+// =================================================================================================
+// async_try_stream_block
+
+pub(super) fn block_macro(input: TokenStream) -> Result<TokenStream> {
+    syn::parse2(input).map(expand_async_try_stream_block)
+}
+
+fn expand_async_try_stream_block(mut expr: Expr) -> TokenStream {
+    Visitor::new(TryStream).visit_expr_mut(&mut expr);
+
+    let gen_function = quote!(::futures_async_stream::try_stream::from_generator);
+    let ret_ty = quote!(::futures_async_stream::reexport::result::Result<(), _>);
+    make_gen_body(&[], &block(vec![Stmt::Expr(expr)]), &gen_function, &quote!(Ok(())), &ret_ty)
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -5,10 +5,9 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
+use futures_core::stream::Stream;
 use pin_project::pin_project;
 use std::future;
-
-pub use futures_core::stream::Stream;
 
 // =================================================================================================
 // GenStream

--- a/src/try_stream.rs
+++ b/src/try_stream.rs
@@ -1,0 +1,69 @@
+use core::{
+    marker::PhantomData,
+    ops::{Generator, GeneratorState},
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures_core::stream::{FusedStream, Stream};
+use pin_project::pin_project;
+use std::future;
+
+// =================================================================================================
+// GenTryStream
+
+/// Wrap a generator in a stream.
+///
+/// This function returns a `GenTryStream` underneath, but hides it in `impl Trait` to give
+/// better error messages (`impl Stream` rather than `GenTryStream<[closure.....]>`).
+#[doc(hidden)]
+pub fn from_generator<G, T, E>(
+    gen: G,
+) -> impl Stream<Item = Result<T, E>> + FusedStream<Item = Result<T, E>>
+where
+    G: Generator<Yield = Poll<T>, Return = Result<(), E>>,
+{
+    GenTryStream { gen, done: false, _phantom: PhantomData }
+}
+
+/// A wrapper around generators used to implement `Stream` for `async`/`await` code.
+#[pin_project]
+#[derive(Debug)]
+struct GenTryStream<G, T, E> {
+    #[pin]
+    gen: G,
+    done: bool,
+    _phantom: PhantomData<(T, E)>,
+}
+
+impl<G, T, E> Stream for GenTryStream<G, T, E>
+where
+    G: Generator<Yield = Poll<T>, Return = Result<(), E>>,
+{
+    type Item = Result<T, E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        let mut this = self.project();
+        let res = future::set_task_context(cx, || match this.gen.as_mut().resume() {
+            GeneratorState::Yielded(x) => x.map(|x| Some(Ok(x))),
+            GeneratorState::Complete(Err(e)) => Poll::Ready(Some(Err(e))),
+            GeneratorState::Complete(Ok(())) => Poll::Ready(None),
+        });
+        if let Poll::Ready(Some(Err(_))) | Poll::Ready(None) = &res {
+            *this.done = true;
+        }
+        res
+    }
+}
+
+impl<G, T, E> FusedStream for GenTryStream<G, T, E>
+where
+    G: Generator<Yield = Poll<T>, Return = Result<(), E>>,
+{
+    fn is_terminated(&self) -> bool {
+        self.done
+    }
+}

--- a/tests/async_stream.rs
+++ b/tests/async_stream.rs
@@ -3,7 +3,6 @@
 
 use futures::{
     executor::block_on,
-    future,
     stream::{self, Stream},
 };
 use futures_async_stream::{async_stream, async_stream_block, for_await};
@@ -14,22 +13,22 @@ pub async fn nested() {
     let _ = async {
         #[for_await]
         for i in stream::iter(vec![1, 2]) {
-            future::lazy(|_| i * i).await;
+            async { i * i }.await;
         }
     };
-    future::lazy(|_| ()).await;
+    async {}.await;
 }
 
 pub async fn nested2() {
     let s = async_stream_block! {
         #[for_await]
         for i in stream::iter(vec![1, 2]) {
-            future::lazy(|_| i * i).await;
+            yield async { i * i }.await;
         }
     };
     #[for_await]
     for _i in s {
-        future::lazy(|_| ()).await;
+        async {}.await;
     }
 }
 

--- a/tests/async_try_stream.rs
+++ b/tests/async_try_stream.rs
@@ -1,0 +1,86 @@
+#![warn(rust_2018_idioms)]
+#![feature(generators, stmt_expr_attributes, proc_macro_hygiene, impl_trait_in_bindings)]
+#![allow(incomplete_features)]
+
+use futures::{
+    executor::block_on,
+    stream::{self, Stream},
+};
+use futures_async_stream::{async_try_stream, async_try_stream_block, for_await};
+
+#[async_try_stream(ok = i32, error = i32)]
+pub async fn nested() {
+    let f = async {
+        #[for_await]
+        for i in stream::iter(vec![Ok(1), Err(2)]) {
+            async { i }.await?;
+        }
+        Ok::<(), i32>(())
+    };
+    f.await?;
+}
+
+pub async fn nested2() -> Result<(), i32> {
+    let s: impl Stream<Item = Result<i32, i32>> = async_try_stream_block! {
+        #[for_await]
+        for i in stream::iter(vec![Ok(1), Err(2)]) {
+            yield async { i }.await?;
+        }
+    };
+    #[for_await]
+    for i in s {
+        async { i }.await?;
+    }
+    Ok::<(), i32>(())
+}
+
+#[async_try_stream(ok = u64, error = i32)]
+async fn stream1() {
+    yield 0;
+    yield Err(1)?;
+}
+
+#[async_try_stream(ok = u32, error = i32)]
+async fn stream3(iter: impl IntoIterator<Item = u32>) {
+    let mut sum = 0;
+    #[for_await]
+    for x in stream::iter(iter) {
+        sum += x;
+        yield x;
+    }
+    if sum == 0 {
+        return Err(0);
+    }
+    yield sum;
+}
+
+#[async_try_stream(ok = i32, error = Box<dyn std::error::Error + Send + Sync + 'static>)]
+pub async fn dyn_trait(stream: impl Stream<Item = String>) {
+    #[for_await]
+    for x in stream {
+        yield x.parse()?;
+    }
+}
+
+#[test]
+fn test() {
+    async fn foo() {
+        let mut v = [Ok(0), Err(1)].iter();
+        #[for_await]
+        for x in stream1() {
+            assert_eq!(x, *v.next().unwrap());
+        }
+
+        let mut v = [1, 2, 3, 4, 10].iter();
+        #[for_await]
+        for x in stream3(v.clone().cloned().take(4)) {
+            assert_eq!(x.unwrap(), *v.next().unwrap());
+        }
+
+        #[for_await]
+        for x in stream3(Vec::new()) {
+            assert_eq!(Err(0), x)
+        }
+    }
+    let _ = block_on(foo());
+}

--- a/tests/elisions.rs
+++ b/tests/elisions.rs
@@ -33,3 +33,6 @@ pub async fn single_ref(x: &i32) {
 pub async fn check_for_name_colision<'_async0, T>(_x: &T, _y: &'_async0 i32) {
     yield
 }
+
+#[test]
+fn test() {}


### PR DESCRIPTION
`?` operator can be used with the `#[async_try_stream]` attribute and `async_try_stream_block!` macro.

```rust
#![feature(generators)]
use futures::stream::Stream;
use futures_async_stream::try_async_stream;

#[async_try_stream(ok = i32, error = Box<dyn std::error::Error + Send + Sync + 'static>)]
async fn foo(stream: impl Stream<Item = String>) {
    #[for_await]
    for x in stream {
        yield x.parse()?;
    }
}
```

Closes #2 