### PR TITLE
Ignore comma at the end of stream

### DIFF
--- a/futures-async-stream-macro/src/parse.rs
+++ b/futures-async-stream-macro/src/parse.rs
@@ -121,6 +121,10 @@ impl Parse for FnOrAsync {
             attrs.append(&mut expr.attrs);
             expr.attrs = attrs;
 
+            if input.peek(Token![,]) {
+                let _: Token![,] = input.parse()?;
+            }
+
             Ok(Self::Async(expr, input.parse()?))
         } else {
             input.parse::<TokenStream>()?; // ignore all inputs

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -180,6 +180,33 @@ pub async fn array() {
     yield [1, 2, 3, 4];
 }
 
+#[allow(clippy::unnecessary_wraps)]
+pub fn some_stream() -> Option<impl Stream> {
+    Some(
+        #[stream]
+        async {
+            yield 1;
+        },
+    )
+}
+
+pub fn stream_tuple() -> (impl Stream, impl Stream, impl Stream) {
+    (
+        #[stream]
+        async {
+            yield 1;
+        },
+        #[stream]
+        async {
+            yield 1;
+        },
+        #[stream]
+        async {
+            yield 1;
+        },
+    )
+}
+
 #[allow(clippy::toplevel_ref_arg)]
 pub mod arguments {
     use super::*;


### PR DESCRIPTION
support #93 
rustfmt would auto format

```rust
pub fn some_tream() -> Option<impl Stream> {
    Some(#[stream] async {
        yield 1;
    })
}
```
to

```rust
pub fn some_tream() -> Option<impl Stream> {
    Some(
        #[stream]
        async {
            yield 1;
        },
    )
}
```

the comma at the end of stream block should be ignored.