### PR TITLE
fix: use block's span for generated body

### DIFF
--- a/futures-async-stream-macro/src/stream.rs
+++ b/futures-async-stream-macro/src/stream.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::{
     Block, ExprAsync, FnArg, Pat, PatIdent, PatType, Result, Signature, Stmt, Token, Type,
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
+    spanned::Spanned as _,
     token,
     visit_mut::VisitMut as _,
 };
@@ -373,7 +374,7 @@ fn make_gen_body(
     };
 
     let task_context = def_site_ident!("__task_context");
-    let body = quote! {
+    let body = quote_spanned! { block.span() =>
         #gen_function(
             #[coroutine]
             static #capture |

--- a/tests/ui/borrow-as-mut.stderr
+++ b/tests/ui/borrow-as-mut.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow value as mutable, as it is not declared as mutable
+error[E0596]: cannot borrow `a` as mutable, as it is not declared as mutable
  --> tests/ui/borrow-as-mut.rs:9:5
   |
 9 |     a.clear(); //~ ERROR E0596

--- a/tests/ui/question-mark-await-type-error.stderr
+++ b/tests/ui/question-mark-await-type-error.stderr
@@ -29,11 +29,14 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 error[E0277]: the `?` operator can only be used in a coroutine that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> tests/ui/question-mark-await-type-error.rs:23:23
    |
-20 | #[stream(item = i32)]
-   | --------------------- this function should return `Result` or `Option` to accept `?`
-...
-23 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-   |                       ^ cannot use the `?` operator in a coroutine that returns `()`
+21 |   async fn async_stream_fn() {
+   |  ____________________________-
+22 | |     for _i in 1..2 {
+23 | |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   | |                       ^ cannot use the `?` operator in a coroutine that returns `()`
+24 | |     }
+25 | | }
+   | |_- this function should return `Result` or `Option` to accept `?`
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> tests/ui/question-mark-await-type-error.rs:30:9
@@ -67,8 +70,12 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 error[E0277]: the `?` operator can only be used in a coroutine that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> tests/ui/question-mark-await-type-error.rs:38:23
    |
-34 | #[stream(item = i32)]
-   | --------------------- this function should return `Result` or `Option` to accept `?`
-...
-38 |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-   |                       ^ cannot use the `?` operator in a coroutine that returns `()`
+35 |   async fn async_stream_fn_and_for_await() {
+   |  __________________________________________-
+36 | |     #[for_await]
+37 | |     for _i in stream(2) {
+38 | |         async {}.await?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+   | |                       ^ cannot use the `?` operator in a coroutine that returns `()`
+39 | |     }
+40 | | }
+   | |_- this function should return `Result` or `Option` to accept `?`


### PR DESCRIPTION
Hi @taiki-e and thanks for your awesome work!

While working with `cargo-llvm-cov`, I noticed that the body of an async stream is marked as skipped lines. It appears that it's because of the compiler cannot somehow link the proc-macro generated lines to the macro input.

By specifying the `block`'s span for the generated `body` (as what this PR changes), the source lines can be correctly instrumented.

----

A minimal reproduction can be:

```rust
#![feature(yield_expr)]
#![feature(coroutines)]

#[futures_async_stream::stream(item = u64, boxed)]
async fn add(left: u64, right: u64) {
    println!("add {} + {}", left, right);
    yield left;
    yield right;
    yield left + right;
}

// With the patch from this PR.
#[futures_async_stream_patched::stream(item = u64, boxed)]
async fn add_patched(left: u64, right: u64) {
    println!("add {} + {}", left, right);
    yield left;
    yield right;
    yield left + right;
}

#[cfg(test)]
mod tests {
    use smol::stream::StreamExt as _;

    use super::*;

    #[test]
    fn it_works() {
        for a in [add, add_patched] {
            let result = std::pin::pin!(a(2, 2));
            smol::block_on(async {
                let mut stream = result;
                assert_eq!(stream.next().await, Some(2));
                assert_eq!(stream.next().await, Some(2));
                assert_eq!(stream.next().await, Some(4));
                assert_eq!(stream.next().await, None);
            })
        }
    }
}

```

Then run
```
cargo llvm-cov test --open
```

We'll get

<img width="597" height="778" alt="image" src="https://github.com/user-attachments/assets/7b1d73ef-c236-41a5-9747-4e2fabde56e4" />
